### PR TITLE
Fix warning with -DSKIP_usd=true

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -9,6 +9,7 @@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	    -DSKIP_usd=true \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 execute_after_dh_auto_build-indep:


### PR DESCRIPTION
The debbuilds are unstable due to a cmake warning. This should ignore the warning

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-debbuilder&build=616)](https://build.osrfoundation.org/view/ign-garden/job/sdformat12-debbuilder/616/) https://build.osrfoundation.org/view/ign-garden/job/sdformat12-debbuilder/616/

~~~
-- Searching for <ignition-utils1> component [cli]
CMake Warning at /usr/share/cmake-3.10/Modules/CMakeFindDependencyMacro.cmake:48 (find_package):
  By not providing "Findignition-utils1-cli.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ignition-utils1-cli", but CMake did not find one.

  Could not find a package configuration file provided by
  "ignition-utils1-cli" (requested version 1.4.0) with any of the following
  names:

    ignition-utils1-cliConfig.cmake
    ignition-utils1-cli-config.cmake

  Add the installation prefix of "ignition-utils1-cli" to CMAKE_PREFIX_PATH
  or set "ignition-utils1-cli_DIR" to a directory containing one of the above
  files.  If "ignition-utils1-cli" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/ignition-utils1/ignition-utils1-config.cmake:196 (find_dependency)
  /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:189 (find_package)
  CMakeLists.txt:110 (ign_find_package)


CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:189 (find_package):
  Found package configuration file:

    /usr/lib/x86_64-linux-gnu/cmake/ignition-utils1/ignition-utils1-config.cmake

  but it set ignition-utils1_FOUND to FALSE so package "ignition-utils1" is
  considered to be NOT FOUND.  Reason given by package:

  ignition-utils1 could not be found because dependency ignition-utils1-cli
  could not be found.

Call Stack (most recent call first):
  CMakeLists.txt:110 (ign_find_package)


-- Looking for ignition-utils1 - not found

CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:189 (find_package):
  By not providing "Findignition-common4.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ignition-common4", but CMake did not find one.

  Could not find a package configuration file provided by "ignition-common4"
  with any of the following names:

    ignition-common4Config.cmake
    ignition-common4-config.cmake

  Add the installation prefix of "ignition-common4" to CMAKE_PREFIX_PATH or
  set "ignition-common4_DIR" to a directory containing one of the above
  files.  If "ignition-common4" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:115 (ign_find_package)


-- Looking for ignition-common4 - not found

-- Looking for pxr - not found

CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnConfigureBuild.cmake:55 (message):
   CONFIGURATION WARNINGS:
   -- Skipping component [usd]: Missing dependency [ignition-utils1] (Components: cli).
      ^~~~~ Set SKIP_usd=true in cmake to suppress this warning.
   
   -- Skipping component [usd]: Missing dependency [ignition-common4] (Components: graphics).
      ^~~~~ Set SKIP_usd=true in cmake to suppress this warning.
   
   -- Skipping component [usd]: Missing dependency [pxr].
      ^~~~~ Set SKIP_usd=true in cmake to suppress this warning.
   
Call Stack (most recent call first):
  CMakeLists.txt:122 (ign_configure_build)


~~~