### PR TITLE
Fix installation of completion / gz scripts

### DIFF
--- a/ubuntu/debian/libsdformat-dev.install
+++ b/ubuntu/debian/libsdformat-dev.install
@@ -2,5 +2,3 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/sdformat12*/*
-usr/lib/ruby/ignition/*.rb
-usr/share/ignition/*.yaml

--- a/ubuntu/debian/libsdformat.install
+++ b/ubuntu/debian/libsdformat.install
@@ -1,1 +1,4 @@
 usr/lib/*/*.so.*
+usr/lib/ruby/ignition/*.rb
+usr/share/ignition/*.yaml
+usr/share/gz/*


### PR DESCRIPTION
* Install bash completion scripts
* Move gz tool scripts to non-dev package

Port of gazebo-release/sdformat9-release#1

Motivated by the following unstable build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-debbuilder&build=647)](https://build.osrfoundation.org/job/sdformat12-debbuilder/647/) https://build.osrfoundation.org/job/sdformat12-debbuilder/647/